### PR TITLE
nn.RNN compatibility

### DIFF
--- a/sru/test_sru.py
+++ b/sru/test_sru.py
@@ -1,0 +1,29 @@
+from sru import SRU
+import torch
+from torch import nn
+import numpy as np
+
+def test_gru_compatible_state_return():
+    N = 5
+    max_len = 7
+    V = 32
+    K = 8
+    K_out = 11
+    num_layers = 5
+    bidirectional = True
+
+    torch.manual_seed(123)
+    np.random.seed(123)
+    lengths = torch.from_numpy(np.random.choice(max_len, N)) + 1
+    tensors = [torch.from_numpy(np.random.choice(V, l, replace=True)) for l in lengths.tolist()]
+    embedder = nn.Embedding(V, K)
+    tensors = nn.utils.rnn.pad_sequence(tensors, batch_first=True)
+    embedded = embedder(tensors)
+
+    sru = SRU(K, K_out, nn_rnn_compatible_return=True, bidirectional=bidirectional, num_layers=num_layers)
+    out, state = sru(embedded)
+    print('state.size()', state.size())
+
+    gru = nn.GRU(K, K_out, bidirectional=bidirectional, num_layers=num_layers)
+    gru_out, gru_state = gru(embedded)
+    print('gru_state.size()', gru_state.size())

--- a/sru/test_sru.py
+++ b/sru/test_sru.py
@@ -50,3 +50,30 @@ def test_packed():
     assert (lengths != lengths3).sum().item() == 0
     print('out3.sum()', out3.sum().item())
     assert out3.sum().item() != out1.sum().item()
+
+def test_gru_compatible_state_return():
+    N = 5
+    max_len = 7
+    V = 32
+    K = 8
+    K_out = 11
+    num_layers = 3
+    bidirectional = True
+
+    print('N', N, 'max_len', max_len, 'num_layers', num_layers, 'bidirectional', bidirectional, 'K', K, 'K_out', K_out)
+
+    torch.manual_seed(123)
+    np.random.seed(123)
+    lengths = torch.from_numpy(np.random.choice(max_len, N)) + 1
+    tensors = [torch.from_numpy(np.random.choice(V, l, replace=True)) for l in lengths.tolist()]
+    embedder = nn.Embedding(V, K)
+    tensors = nn.utils.rnn.pad_sequence(tensors)
+    embedded = embedder(tensors)
+
+    sru = SRU(K, K_out, nn_rnn_compatible_return=True, bidirectional=bidirectional, num_layers=num_layers)
+    out, state = sru(embedded)
+    print('state.size()', state.size())
+
+    gru = nn.GRU(K, K_out, bidirectional=bidirectional, num_layers=num_layers)
+    gru_out, gru_state = gru(embedded)
+    print('gru_state.size()', gru_state.size())

--- a/sru/test_sru.py
+++ b/sru/test_sru.py
@@ -9,15 +9,17 @@ def test_gru_compatible_state_return():
     V = 32
     K = 8
     K_out = 11
-    num_layers = 5
+    num_layers = 3
     bidirectional = True
+
+    print('N', N, 'max_len', max_len, 'num_layers', num_layers, 'bidirectional', bidirectional, 'K', K, 'K_out', K_out)
 
     torch.manual_seed(123)
     np.random.seed(123)
     lengths = torch.from_numpy(np.random.choice(max_len, N)) + 1
     tensors = [torch.from_numpy(np.random.choice(V, l, replace=True)) for l in lengths.tolist()]
     embedder = nn.Embedding(V, K)
-    tensors = nn.utils.rnn.pad_sequence(tensors, batch_first=True)
+    tensors = nn.utils.rnn.pad_sequence(tensors)
     embedded = embedder(tensors)
 
     sru = SRU(K, K_out, nn_rnn_compatible_return=True, bidirectional=bidirectional, num_layers=num_layers)


### PR DESCRIPTION
Provides compatibility with nn.RNN and nn.GRU:
- can pass in input in packed form, and receive output also in packed form
- new parameter `nn_rnn_compatible_return`, which makes the returned state compatible with nn.RNN and nn.GRU