### PR TITLE
Custom m utils create

### DIFF
--- a/sru/__init__.py
+++ b/sru/__init__.py
@@ -4,5 +4,7 @@ sru - Simple Recurrent Unit
 sru provides a PyTorch implementation of the simple recurrent neural network cell described
 in "Simple Recurrent Units for Highly Parallelizable Recurrence."
 """
-from sru.version import __version__  # noqa: F401
-from sru.modules import SRU, SRUCell  # noqa: F401
+from sru.version import __version__
+from sru.modules import SRU, SRUCell
+
+__all__ = ['SRU', 'SRUCell']

--- a/sru/custom_m_utils.py
+++ b/sru/custom_m_utils.py
@@ -85,6 +85,13 @@ def convert_sru_to_linears(sru: SRU):
 
     If projection is used, then custom_m will contain
     a Sequential[Linear, Linear], otherwise it will contain a Linear.
+
+    Parameters
+    ----------
+    sru: SRU
+        sru to convert to custom_m
+    linear_first_layer: bool
+        if True and first layer is projected, convert to un-projected
     """
     for cell in sru.rnn_lst:
         convert_sru_cell_to_linears(cell)

--- a/sru/custom_m_utils.py
+++ b/sru/custom_m_utils.py
@@ -1,0 +1,133 @@
+from torch import nn
+import logging
+from sru import SRU, SRUCell
+
+logger = logging.getLogger(__name__)
+
+
+def convert_sru_cell_to_linears(cell: SRUCell):
+    if cell.custom_m is not None:
+        if cell.custom_m.__class__.__name__ == 'ProjectedLinear':
+            # leave as-is
+            logger.debug('cell already ProjectedLinear, leaving as-is')
+            return
+        elif isinstance(cell.custom_m, nn.Sequential):
+            if len(cell.custom_m) != 2:
+                raise Exception(
+                    'custom_m already in use, cannot convert to Linears ' + str(cell.custom_m))
+            if not isinstance(cell.custom_m[0], nn.Linear):
+                raise Exception(
+                    'custom_m already in use, cannot convert to Linears ' + str(cell.custom_m))
+            if not isinstance(cell.custom_m[1], nn.Linear):
+                raise Exception(
+                    'custom_m already in use, cannot convert to Linears ' + str(cell.custom_m))
+            # already converted, no need to do anything
+            logger.debug('cell already Sequential[Linear, Linear], leaving as-is')
+            return
+        elif isinstance(cell.custom_m, nn.Linear):
+            # nothing to do
+            logger.debug('cell already Linear, leaving as-is')
+            return
+        else:
+            raise Exception(
+                'custom_m already in use, cannot convert to Linears ' + str(cell.custom_m))
+    else:
+        # this is mostly to placate mypy:
+        if cell.weight is None:
+            raise Exception("Shouldn't be here. Logic error in SRU code")
+        # if getattr(cell, 'weight_proj', None) is None:
+        if cell.weight_proj is None:
+            # not using projection, convert to Linear custom_m
+            logger.debug('cell not using projection, converting to Linear')
+            input_size, output_size = cell.weight.data.size()
+            device = cell.weight.device
+            cell.custom_m = nn.Linear(input_size, output_size, bias=False).to(device)
+            cell.custom_m.weight.data[:] = cell.weight.data.transpose(0, 1)
+            cell.weight = None
+        else:
+            # using projection, convert to Sequential[Linear, Linear]
+            logger.debug('cell using projection, converting to Sequential[Linear, Linear]')
+            input_size, projection_size = cell.weight_proj.size()
+            output_size = cell.weight.size(1)
+            device = cell.weight.device
+            first = cell.weight_proj.data.transpose(0, 1)
+            second = cell.weight.data.transpose(0, 1)
+            linear1 = nn.Linear(input_size, projection_size, bias=False).to(device)
+            linear2 = nn.Linear(projection_size, output_size, bias=False).to(device)
+            linear1.weight.data[:] = first
+            linear2.weight.data[:] = second
+            cell.custom_m = nn.Sequential(
+                linear1, linear2)
+            cell.weight = None
+            cell.weight_proj = None
+
+
+def convert_sru_to_linears(sru: SRU):
+    """
+    Convert sru module to use nn.Linear, in the custom_m.
+    You might do this to facilitate:
+    - using quantization (which sometimes only works on Linear modules)
+    - FLOP pruning (https://arxiv.org/abs/1910.04732)
+
+    custom_m module is used to multiply the inputs by weight matrices, to
+    give the U matrix. This is the largest matrix multiplication in SRU,
+    and typically dominates the execution time.
+
+    If an sru cell has projection_size more than zero, then the matrix is factorized
+    into two. This can give lower latencies, and is also useful when
+    using FLOP pruning.
+
+    When converting SRU using this method, custom_m must not already
+    being used. If custom_m is already being used in a cell, then an
+    Exception will be thrown, since the custom_m
+    is needed to store the Linear modules.
+
+    If projection is used, then custom_m will contain
+    a Sequential[Linear, Linear], otherwise it will contain a Linear.
+    """
+    for cell in sru.rnn_lst:
+        convert_sru_cell_to_linears(cell)
+
+
+def create_sru_using_linears(
+        projection_size: int = 0,
+        custom_m: None = None,
+        **sru_kwargs):
+    """
+    Create SRU using nn.Linear, in the custom_m.
+    You might do this to facilitate:
+    - using quantization (which sometimes only works on Linear modules)
+    - FLOP pruning (https://arxiv.org/abs/1910.04732)
+
+    custom_m module is used to multiply the inputs by weight matrices, to
+    give the U matrix. This is the largest matrix multiplication in SRU,
+    and typically dominates the execution time.
+
+    If projection_size is more than zero, then the matrix is factorized
+    into two. This can give lower latencies, and is also useful when
+    using FLOP pruning.
+
+    When creating SRU using this method, you cannot specify a custom_m,
+    since the custom_m will be used to store the Linear modules.
+
+    If projection size is more than zero, then custom_m will contain
+    a Sequential[Linear, Linear], otherwise it will contain a Linear.
+
+    This is implemented by creating sru then converting it because:
+    1. easier to test (can compare sru before/after conversion)
+    2. don't need to know about how to dimension the matrices correctly,
+       since can just copy the dimensions of the already-created matrices
+       (so plausibly less fragile to internal sru changes, perhaps)
+
+    Parameters
+    ----------
+    projection_size: int
+        size of projection
+        if 0, then no projection
+    custom_m: None
+        must be None
+    """
+    if custom_m is not None:
+        raise Exception('custom_m must be None when using create_sru_using_linears')
+    sru = SRU(projection_size=projection_size, custom_m=None, **sru_kwargs)
+    convert_sru_to_linears(sru)

--- a/sru/modules.py
+++ b/sru/modules.py
@@ -102,8 +102,6 @@ class SRUCell(nn.Module):
         self.projection_size = 0
         self.rnn_dropout = float(rnn_dropout)
         self.dropout = float(dropout)
-        self.weight = None
-        self.weight_proj = None
         self.bidirectional = bidirectional
         self.has_skip_term = has_skip_term
         self.highway_bias = highway_bias
@@ -141,6 +139,9 @@ class SRUCell(nn.Module):
                     self.projection_size,
                     self.output_size * self.num_matrices
                 ))
+        else:
+            self.weight = None
+            self.weight_proj = None
         self.weight_c = nn.Parameter(torch.Tensor(2 * self.output_size))
         self.bias = nn.Parameter(torch.Tensor(2 * self.output_size))
 

--- a/sru/modules.py
+++ b/sru/modules.py
@@ -99,8 +99,11 @@ class SRUCell(nn.Module):
         self.input_size = input_size
         self.hidden_size = hidden_size  # hidden size per direction
         self.output_size = hidden_size * 2 if bidirectional else hidden_size
+        self.projection_size = 0
         self.rnn_dropout = float(rnn_dropout)
         self.dropout = float(dropout)
+        self.weight = None
+        self.weight_proj = None
         self.bidirectional = bidirectional
         self.has_skip_term = has_skip_term
         self.highway_bias = highway_bias

--- a/test/sru/test_custom_m_utils.py
+++ b/test/sru/test_custom_m_utils.py
@@ -1,0 +1,101 @@
+import copy
+import torch
+from torch import nn
+from sru import custom_m_utils, SRU, SRUCell
+import pytest
+
+
+EPS = 1e-6
+
+
+@pytest.mark.parametrize(
+    "d_in,d_out", [
+        (4, 3),
+        (3, 4),
+        (4, 4),
+    ]
+)
+def test_convert_sru_cell_to_linear(d_in, d_out):
+    cell = SRUCell(d_in, d_out)
+    cell2 = copy.deepcopy(cell)
+
+    custom_m_utils.convert_sru_cell_to_linears(cell2)
+    assert cell2.weight is None
+    assert cell2.weight_proj is None
+    assert cell2.custom_m is not None
+    assert isinstance(cell2.custom_m, nn.Linear)
+    inputs = torch.rand(3, d_in)
+    outputs1, _ = cell(inputs)
+    outputs2, _ = cell2(inputs)
+    assert (outputs1 - outputs2).abs().max() < EPS
+
+
+@pytest.mark.parametrize(
+    "d_in,d_proj,d_out", [
+        (3, 2, 4),
+        (4, 3, 4),
+        (4, 2, 3),
+    ]
+)
+def test_convert_sru_cell_with_proj_to_custom(d_in, d_proj, d_out):
+    cell = SRUCell(d_in, d_out, n_proj=d_proj)
+    cell2 = copy.deepcopy(cell)
+    custom_m_utils.convert_sru_cell_to_linears(cell2)
+    assert cell2.weight is None
+    assert cell2.weight_proj is None
+    assert cell2.custom_m is not None
+    assert isinstance(cell2.custom_m, nn.Sequential)
+    assert len(cell2.custom_m) == 2
+    assert isinstance(cell2.custom_m[0], nn.Linear)
+    assert isinstance(cell2.custom_m[1], nn.Linear)
+    inputs = torch.rand(3, d_in)
+    outputs1, _ = cell(inputs)
+    outputs2, _ = cell2(inputs)
+    assert (outputs1 - outputs2).abs().max() < EPS
+
+
+@pytest.mark.parametrize(
+    "d_in,d_out", [
+        (4, 3),
+        (3, 4),
+        (4, 4),
+    ]
+)
+def test_convert_sru_to_custom(d_in, d_out):
+    sru = SRU(d_in, d_out, num_layers=4, bidirectional=False)
+    sru2 = copy.deepcopy(sru)
+    custom_m_utils.convert_sru_to_linears(sru2)
+    for cell2 in sru2.rnn_lst:
+        assert cell2.weight is None
+        assert cell2.weight_proj is None
+        assert cell2.custom_m is not None
+        assert isinstance(cell2.custom_m, nn.Linear)
+    inputs = torch.rand(5, 3, d_in)
+    outputs1, _ = sru(inputs)
+    outputs2, _ = sru2(inputs)
+    assert (outputs1 - outputs2).abs().max() < EPS
+
+
+@pytest.mark.parametrize(
+    "d_in,d_proj,d_out", [
+        (3, 2, 4),
+        (4, 3, 4),
+        (4, 2, 3),
+    ]
+)
+def test_convert_sru_with_proj_to_custom(d_in, d_proj, d_out):
+    sru = SRU(d_in, d_out, num_layers=4, bidirectional=False, projection_size=d_proj)
+    sru2 = copy.deepcopy(sru)
+    custom_m_utils.convert_sru_to_linears(sru2)
+    for cell2 in sru2.rnn_lst:
+        assert cell2.weight is None
+        assert cell2.weight_proj is None
+        assert cell2.custom_m is not None
+        assert isinstance(cell2.custom_m, nn.Sequential)
+        assert len(cell2.custom_m) == 2
+        assert isinstance(cell2.custom_m[0], nn.Linear)
+        assert isinstance(cell2.custom_m[1], nn.Linear)
+    inputs = torch.rand(5, 3, d_in)
+    outputs1, _ = sru(inputs)
+    outputs2, _ = sru2(inputs)
+    assert (outputs1 - outputs2).abs().max() < EPS


### PR DESCRIPTION
- create `custom_m_utils.py` module, which provides utilities for creating an SRU using Linears or Sequential[Linear,Linear], in custom_m; and for converting an existing SRU to use linears or Sequential[Linear,Linear], without loss of already-trained parameters.
- create unit tests for `custom_m_utils.py`