### PR TITLE
Vector of proj booleans

### DIFF
--- a/sru/modules.py
+++ b/sru/modules.py
@@ -22,7 +22,7 @@ class SRUCell(nn.Module):
                      'dropout', 'bidirectional', 'has_skip_term', 'highway_bias',
                      'v1', 'rescale', 'activation_type', 'activation', 'custom_m',
                      'projection_size', 'num_matrices', 'layer_norm', 'weight_proj',
-                     'scale_x', 'normalize_after', 'weight_c_init',]
+                     'scale_x', 'normalize_after', 'weight_c_init', ]
 
     scale_x: Tensor
     weight_proj: Optional[Tensor]
@@ -152,7 +152,7 @@ class SRUCell(nn.Module):
         # scaling constant used in highway connections when rescale=True
         self.register_buffer('scale_x', torch.FloatTensor([0]))
 
-        self.layer_norm: Optional[nn.Module]= None
+        self.layer_norm: Optional[nn.Module] = None
         if layer_norm:
             if normalize_after:
                 self.layer_norm = nn.LayerNorm(self.output_size)

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -7,7 +7,6 @@ test:
 import torch
 import sru
 import pytest
-import sys
 
 
 EPSILON = 1e-6
@@ -18,7 +17,7 @@ ARTIFACT_DIR = 'test/regression/artifacts'
 
 @pytest.mark.parametrize(
     "sru_prev_version",
-    ["2.3.5"]
+    []  # TODO: add in 3.0.0
 )
 def test_regression(sru_prev_version):
     """


### PR DESCRIPTION
- allow SRU constructor to take a sequence of projtection sizes
- change srucell projection_size parameter name to projection_size
- no longer enforce that projection_size < input_size and projection_size < hidden_size
- add `__getitem__(self, n)` to sru, to return `n`th layer