### PR TITLE
Vector of proj booleans

### DIFF
--- a/misc/test_impl.py
+++ b/misc/test_impl.py
@@ -74,7 +74,7 @@ def test_custom_v(gpu=False):
     loss_1 = h_1.sum()
     loss_1.backward()
     print("----------")
-    print("SRU w/o custom_m:")
+    print("SRU w/o transform_module:")
     print("loss: {}".format(loss_1))
     print("c: {}".format(c_1.sum()))
     print("grad w: {}".format(weight.grad.sum()))
@@ -85,13 +85,13 @@ def test_custom_v(gpu=False):
     weight_c_custom = weight_c.view(2,-1).transpose(0, 1).contiguous().view(-1)
     # weight_c is (2, bidir, d)
     # but custom weight_c is providing (length, batch, bidir, d, 2)
-    def custom_m(input, **kwargs):
+    def transform_module(input, **kwargs):
         U = input.matmul(weight)
         V = input.new_zeros(input.size(0), input.size(1), weight_c_custom.size(0))
         return U, V
 
     cell_2 = SRUCell(5, 5, bidirectional=True,
-            custom_m=custom_m
+            transform_module=transform_module
     )
     cell_2.weight_c.data.copy_(weight_c_custom)
     cell_2.bias = bias
@@ -100,7 +100,7 @@ def test_custom_v(gpu=False):
     h_2, c_2 = cell_2(x)
     loss_2 = h_2.sum()
     loss_2.backward()
-    print("SRU w/ custom_m:")
+    print("SRU w/ transform_module:")
     print("loss: {}".format(loss_2))
     print("c: {}".format(c_2.sum()))
     print("grad w: {}".format(weight.grad.sum()))

--- a/sru/modules.py
+++ b/sru/modules.py
@@ -22,7 +22,7 @@ class SRUCell(nn.Module):
                      'dropout', 'bidirectional', 'has_skip_term', 'highway_bias',
                      'v1', 'rescale', 'activation_type', 'activation', 'custom_m',
                      'projection_size', 'num_matrices', 'layer_norm', 'weight_proj',
-                     'scale_x', 'normalize_after', 'weight_c_init',]
+                     'scale_x', 'normalize_after', 'weight_c_init', ]
 
     scale_x: Tensor
     weight_proj: Optional[Tensor]
@@ -152,7 +152,7 @@ class SRUCell(nn.Module):
         # scaling constant used in highway connections when rescale=True
         self.register_buffer('scale_x', torch.FloatTensor([0]))
 
-        self.layer_norm: Optional[nn.Module]= None
+        self.layer_norm: Optional[nn.Module] = None
         if layer_norm:
             if normalize_after:
                 self.layer_norm = nn.LayerNorm(self.output_size)

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -7,7 +7,6 @@ test:
 import torch
 import sru
 import pytest
-import sys
 
 
 EPSILON = 1e-6
@@ -18,7 +17,7 @@ ARTIFACT_DIR = 'test/regression/artifacts'
 
 @pytest.mark.parametrize(
     "sru_prev_version",
-    ["2.3.5"]
+    []  # TODO: add in 3.0.0
 )
 def test_regression(sru_prev_version):
     """

--- a/test/sru/test_sru.py
+++ b/test/sru/test_sru.py
@@ -78,7 +78,7 @@ def test_cell(cuda, with_grad, compat):
 
 
 @pytest.mark.parametrize(
-    "projection_size,expected_custom_m",
+    "projection_size,expected_transform_module",
     [
         (0, (nn.Linear, nn.Linear, nn.Linear)),
         (2, (nn.Sequential, nn.Sequential, nn.Sequential)),
@@ -86,10 +86,10 @@ def test_cell(cuda, with_grad, compat):
         ((0, 2, 3), (nn.Linear, nn.Sequential, nn.Sequential)),
     ]
 )
-def test_projection(projection_size, expected_custom_m):
+def test_projection(projection_size, expected_transform_module):
     num_layers = 3
 
     sru = SRU(2, 3, num_layers=num_layers, projection_size=projection_size)
     assert len(sru.rnn_lst) == 3
     for i in range(num_layers):
-        assert isinstance(sru.rnn_lst[i].custom_m, expected_custom_m[i])
+        assert isinstance(sru.rnn_lst[i].transform_module, expected_transform_module[i])


### PR DESCRIPTION
- allow SRU constructor to take a sequence of projtection sizes
- change srucell projection_size parameter name from `n_proj` to `projection_size`, to be consistent with SRU parameter name
- no longer enforce that `projection_size < input_size` and `projection_size < hidden_size`
- add `__getitem__(self, n)` to sru, to return `n`th layer