### PR TITLE
Enable both Pytorch native AMP and Nvidia APEX AMP for SRU

### DIFF
--- a/sru/ops.py
+++ b/sru/ops.py
@@ -96,48 +96,31 @@ def elementwise_recurrence_gpu(U: Tensor,
     """
     from .cuda_functional import SRU_Compute_GPU
 
-    in_autocast = getattr(torch, 'is_autocast_enabled', lambda: False)()
-    if in_autocast:
-        with torch.cuda.amp.autocast(enabled=False):
-            cast = torch.Tensor.half if amp_recurrence_fp16 else torch.Tensor.float
+    if amp_recurrence_fp16:
+        cast = torch.Tensor.half
 
-            U = cast(U)
-            x = cast(x)
-            weight_c = cast(weight_c)
-            bias = cast(bias)
-            c_init = cast(c_init)
-            scale_x = cast(scale_x) if scale_x is not None else scale_x
-            dropout_mask_c = cast(dropout_mask_c) if dropout_mask_c is not None else dropout_mask_c
+        U = cast(U)
+        x = cast(x)
+        weight_c = cast(weight_c)
+        bias = cast(bias)
+        c_init = cast(c_init)
+        scale_x = cast(scale_x) if scale_x is not None else scale_x
+        dropout_mask_c = cast(dropout_mask_c) if dropout_mask_c is not None else dropout_mask_c
 
-            return SRU_Compute_GPU.apply(
-                U,
-                x,
-                weight_c,
-                bias,
-                c_init,
-                activation_type,
-                hidden_size,
-                bidirectional,
-                has_skip_term,
-                scale_x,
-                dropout_mask_c,
-                mask_pad
-            )
-    else:
-        return SRU_Compute_GPU.apply(
-            U,
-            x,
-            weight_c,
-            bias,
-            c_init,
-            activation_type,
-            hidden_size,
-            bidirectional,
-            has_skip_term,
-            scale_x,
-            dropout_mask_c,
-            mask_pad
-        )
+    return SRU_Compute_GPU.apply(
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        activation_type,
+        hidden_size,
+        bidirectional,
+        has_skip_term,
+        scale_x,
+        dropout_mask_c,
+        mask_pad
+    )
 
 
 @torch.jit.unused


### PR DESCRIPTION
Hi!

I was happily using SRUs with Pytorch native AMP, however I started experimenting with training using [Microsoft DeepSpeed](https://github.com/microsoft/DeepSpeed) and bumped in to [an issue](https://github.com/microsoft/DeepSpeed/issues/697).

Basically the issues is that I observed that FP16 training using DeepSpeed doesn't work for both GRUs and SRUs. However when using Nvidia APEX AMP, DeepSpeed training using GRUs does work.

So, based on the tips in [one of your issues](https://github.com/asappresearch/sru/issues/98),  I started looking in to how I could enable Pytorch native AMP **and** Nvidia APEX AMP for SRUs, so I could train models based on SRUs using DeepSpeed.

That is why I created this pull request. Basically, I found that by making the code simpler, I can make SRUs work with both methods of AMP.

Now `amp_recurrence_fp16` can be used for both types of AMP. When `amp_recurrence_fp16=True`, the tensor's are cast to `float16`, otherwise nothing special happens. So, I also removed the `torch.cuda.amp.autocast(enabled=False)` region; I might be wrong, but it seems that we don't need it.

I did some tests with my own code and it works in the different scenarios of interest:
 * Using PyTorch native AMP, not using DeepSpeed
 * Not using PyTorch native AMP, not using DeepSpeed
 * Using Nvidia APEX AMP, using DeepSpeed
 * Not using Nvidia APEX AMP, using DeepSpeed

It would be beneficial if we can test this with an official SRU repo test, maybe repurposing the [`language_model/train_lm.py`](https://github.com/asappresearch/sru/blob/master/language_model/train_lm.py)?