### PR TITLE
fp16 speed & memory improvement

### DIFF
--- a/experiments/srupp_experiments/train_enwik8.py
+++ b/experiments/srupp_experiments/train_enwik8.py
@@ -309,6 +309,7 @@ def main(args):
                 niter += 1
 
                 if local_rank == 0 and (niter == args.max_iter or niter % args.eval_period == 0):
+                    torch.cuda.empty_cache()
                     dev_ppl, dev_loss = eval_model(model_, dev)
                     dev_writer.add_scalar('loss/lm_loss', dev_loss, niter)
                     dev_writer.add_scalar('loss/avg_loss', dev_loss, niter)

--- a/experiments/srupp_experiments/train_lm1b.py
+++ b/experiments/srupp_experiments/train_lm1b.py
@@ -317,6 +317,7 @@ def main(args):
             niter += 1
 
             if local_rank == 0 and (niter == args.max_iter or niter % args.eval_period == 0):
+                torch.cuda.empty_cache()
                 dev_ppl, dev_loss = eval_model(model_, dev)
                 dev_writer.add_scalar('loss/lm_loss', dev_loss, niter)
                 dev_writer.add_scalar('loss/avg_loss', dev_loss, niter)

--- a/experiments/srupp_experiments/train_wt103.py
+++ b/experiments/srupp_experiments/train_wt103.py
@@ -328,6 +328,7 @@ def main(args):
                 niter += 1
 
                 if local_rank == 0 and (niter == args.max_iter or niter % args.eval_period == 0):
+                    torch.cuda.empty_cache()
                     dev_ppl, dev_loss = eval_model(model_, dev)
                     dev_writer.add_scalar('loss/lm_loss', dev_loss, niter)
                     dev_writer.add_scalar('loss/avg_loss', dev_loss, niter)

--- a/sru/csrc/sru_cuda_impl.cpp
+++ b/sru/csrc/sru_cuda_impl.cpp
@@ -496,11 +496,11 @@ void sru_bi_backward(
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sru_forward_simple", &sru_forward_simple, "SRU forward (CUDA version)");
   m.def("sru_backward_simple", &sru_backward_simple, "SRU backward (CUDA version)");
-  m.def("sru_bi_backward_simple", &sru_bi_backward_simple, "SRU bidirectional backward (CUDA version)");
   m.def("sru_bi_forward_simple", &sru_bi_forward_simple, "SRU bidirectional forward (CUDA version)");
+  m.def("sru_bi_backward_simple", &sru_bi_backward_simple, "SRU bidirectional backward (CUDA version)");
 
   m.def("sru_forward", &sru_forward, "SRU forward (CUDA version)");
   m.def("sru_backward", &sru_backward, "SRU backward (CUDA version)");
-  m.def("sru_bi_backward", &sru_bi_backward, "SRU bidirectional backward (CUDA version)");
   m.def("sru_bi_forward", &sru_bi_forward, "SRU bidirectional forward (CUDA version)");
+  m.def("sru_bi_backward", &sru_bi_backward, "SRU bidirectional backward (CUDA version)");
 }

--- a/sru/csrc/sru_cuda_impl.cpp
+++ b/sru/csrc/sru_cuda_impl.cpp
@@ -2,6 +2,80 @@
 #include <vector>
 
 //  unidirectional forward()
+void sru_cuda_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size);
+//  U: the result of grouped multiplication
+//  The size of U is [length, batch_size, hidden_size, 3]
+
+//  unidirectional backward()
+void sru_cuda_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size);
+
+//  bidirectional forward()
+void sru_cuda_bi_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size);
+
+//  bidirectional backward()
+void sru_cuda_bi_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size);
+
+//  unidirectional forward()
 void sru_cuda_forward(
         torch::Tensor & h,
         torch::Tensor & c,
@@ -98,6 +172,150 @@ void sru_cuda_bi_backward(
 #define CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+
+//  unidirectional forward()
+void sru_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    sru_cuda_forward_simple(
+        h,
+        c,
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        mask_c,
+        mask_pad,
+        length,
+        batch_size,
+        hidden_size);
+}
+
+//  unidirectional backward()
+void sru_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    sru_cuda_backward_simple(
+        grad_u,
+        grad_x,
+        grad_wc,
+        grad_bias,
+        grad_init,
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        mask_c,
+        mask_pad,
+        c,
+        grad_h,
+        grad_last,
+        length,
+        batch_size,
+        hidden_size);
+}
+
+//  bidirectional forward()
+void sru_bi_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    sru_cuda_bi_forward_simple(
+        h,
+        c,
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        mask_c,
+        mask_pad,
+        length,
+        batch_size,
+        hidden_size);
+}
+
+//  bidirectional backward()
+void sru_bi_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    sru_cuda_bi_backward_simple(
+        grad_u,
+        grad_x,
+        grad_wc,
+        grad_bias,
+        grad_init,
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        mask_c,
+        mask_pad,
+        c,
+        grad_h,
+        grad_last,
+        length,
+        batch_size,
+        hidden_size);
+}
 
 //  unidirectional forward()
 void sru_forward(
@@ -276,8 +494,13 @@ void sru_bi_backward(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("sru_forward_simple", &sru_forward_simple, "SRU forward (CUDA version)");
+  m.def("sru_backward_simple", &sru_backward_simple, "SRU backward (CUDA version)");
+  m.def("sru_bi_backward_simple", &sru_bi_backward_simple, "SRU bidirectional backward (CUDA version)");
+  m.def("sru_bi_forward_simple", &sru_bi_forward_simple, "SRU bidirectional forward (CUDA version)");
+
   m.def("sru_forward", &sru_forward, "SRU forward (CUDA version)");
-  m.def("sru_bi_forward", &sru_bi_forward, "SRU bidirectional forward (CUDA version)");
   m.def("sru_backward", &sru_backward, "SRU backward (CUDA version)");
   m.def("sru_bi_backward", &sru_bi_backward, "SRU bidirectional backward (CUDA version)");
+  m.def("sru_bi_forward", &sru_bi_forward, "SRU bidirectional forward (CUDA version)");
 }

--- a/sru/csrc/sru_cuda_kernel.cu
+++ b/sru/csrc/sru_cuda_kernel.cu
@@ -37,42 +37,38 @@ __global__ void sru_cuda_forward_kernel_simple(
                         const int batch,
                         const int d)
 {
-    const int ncols = batch*d;
+    const int ncols = batch * d;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
     const int ncols_u = ncols * 3;
     const int ncols_x = ncols;
 
-    const auto wc1 = *(weight_c + (col%d));
-    const auto wc2 = *(weight_c + (col%d) + d);
+    const auto wc1 = *(weight_c + (col % d));
+    const auto wc2 = *(weight_c + (col % d) + d);
 
-    const auto bias1 = *(bias + (col%d));
-    const auto bias2 = *(bias + (col%d) + d);
+    const auto bias1 = *(bias + (col % d));
+    const auto bias2 = *(bias + (col % d) + d);
     const auto  mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     auto cur = *(init + col);
     const auto* up = u + (col * 3);
     const auto* xp = x + col;
-    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d));
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d));
     auto* cp = c + col;
     auto* hp = h + col;
 
-    for (int row = 0; row < len; ++row)
-    {
+    for (int row = 0; row < len; ++row) {
         if ((pad_p == NULL) || !(*pad_p)) {
             const auto u0 = *up;
             const auto u1 = *(up + 1);
             const auto u2 = *(up + 2);
 
             const auto x_val = *xp;
-            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
-            cur = (cur-u0)*g1 + u0;
+            const auto g1 = sigmoidf(u1 + wc1 * cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * cur + bias2);
+            cur = (cur - u0) * g1 + u0;
             *hp = (cur - x_val) * mask * g2 + x_val;
         } 
-        //else {
-        //    *hp = 0;  // output 0 for a pad token
-        //}
         *cp = cur;  // useful for backward
         up += ncols_u;
         cp += ncols;
@@ -103,18 +99,18 @@ __global__ void sru_cuda_backward_kernel_simple(
                         const int batch,
                         const int d)
 {
-    const int ncols = batch*d;
+    const int ncols = batch * d;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
     const int ncols_u = ncols * 3;
     const int ncols_x = ncols;
 
-    const auto wc1 = *(weight_c + (col%d));
-    const auto wc2 = *(weight_c + (col%d) + d);
+    const auto wc1 = *(weight_c + (col % d));
+    const auto wc2 = *(weight_c + (col % d) + d);
 
-    const auto bias1 = *(bias + (col%d));
-    const auto bias2 = *(bias + (col%d) + d);
+    const auto bias1 = *(bias + (col % d));
+    const auto bias2 = *(bias + (col % d) + d);
     const auto mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     scalar_t gwc1 = 0;
     scalar_t gwc2 = 0;
@@ -122,18 +118,18 @@ __global__ void sru_cuda_backward_kernel_simple(
     scalar_t gbias2 = 0;
     auto cur = *(grad_last + col);
 
-    const auto* up = u + (col * 3) + (len-1)*ncols_u;
-    const auto* xp = x + col + (len-1)*ncols;
-    const auto* cp = c + col + (len-1)*ncols;
-    const auto* ghp = grad_h + col + (len-1)*ncols;
-    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d) + (len-1)*batch);
-    auto* gup = grad_u + (col * 3) + (len-1)*ncols_u;
-    auto* gxp = grad_x + col + (len-1)*ncols;
+    const auto* up = u + (col * 3) + (len - 1) * ncols_u;
+    const auto* xp = x + col + (len - 1) * ncols;
+    const auto* cp = c + col + (len - 1) * ncols;
+    const auto* ghp = grad_h + col + (len - 1) * ncols;
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : 
+                                 (mask_pad + (col / d) + (len - 1) * batch);
+    auto* gup = grad_u + (col * 3) + (len - 1) * ncols_u;
+    auto* gxp = grad_x + col + (len - 1) * ncols;
 
-    for (int row = len-1; row >= 0; --row)
-    {
+    for (int row = len-1; row >= 0; --row) {
         if ((pad_p == NULL) || !(*pad_p)) {
-            const auto prev_c_val = row ? (*(cp-ncols)) : (*(init+col));
+            const auto prev_c_val = row ? (*(cp - ncols)) : (*(init + col));
             const auto c_val = *cp;
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -141,35 +137,35 @@ __global__ void sru_cuda_backward_kernel_simple(
 
             const auto x_val = *xp;
             const auto gh_val = *ghp;
-            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+            const auto g1 = sigmoidf(u1 + wc1 * prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * prev_c_val + bias2);
 
             // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
             // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + g0
 
             // gradient with respect to values in the second gate g2
-            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            const auto gg2 = gh_val * (c_val - x_val) * mask * (g2 * (1.f - g2));
             gbias2 += gg2;
-            gwc2 += gg2*prev_c_val;
+            gwc2 += gg2 * prev_c_val;
 
             // gradient with respect to c[t]
             const auto gc = gh_val * mask * g2 + cur;
 
             // gradient with respect to values in the first gate g1
-            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            const auto gg1 = gc * (prev_c_val - u0) * (g1 * (1.f - g1));
             gbias1 += gg1;
-            gwc1 += gg1*prev_c_val;
+            gwc1 += gg1 * prev_c_val;
 
             // gradient with respect to c[t-1]
-            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+            cur = gc * g1 + gg1 * wc1 + gg2 * wc2;
 
             // gradient with respect to U
-            *gup = gc*(1.f-g1);
+            *gup = gc * (1.f - g1);
             *(gup + 1) = gg1;
             *(gup + 2) = gg2;
  
             // gradient with respect to x[t]
-            *gxp = gh_val*(1.f-g2*mask);
+            *gxp = gh_val * (1.f - g2 * mask);
         }
 
         up -= ncols_u;
@@ -181,11 +177,6 @@ __global__ void sru_cuda_backward_kernel_simple(
         pad_p = mask_pad ? (pad_p - batch) : NULL;
     }
 
-    //const int bias_idx = col % d;
-    //atomicAdd(grad_wc + bias_idx, gwc1);
-    //atomicAdd(grad_wc + bias_idx + d, gwc2);
-    //atomicAdd(grad_bias + bias_idx, gbias1);
-    //atomicAdd(grad_bias + bias_idx + d, gbias2);
     *(grad_wc + col) = gwc1;
     *(grad_wc + col + ncols) = gwc2;
     *(grad_bias + col) = gbias1;
@@ -208,7 +199,7 @@ __global__ void sru_cuda_bi_forward_kernel_simple(
                         const int batch,
                         const int d)
 {
-    const int ncols = batch*d*2;
+    const int ncols = batch * d * 2;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
@@ -216,48 +207,44 @@ __global__ void sru_cuda_bi_forward_kernel_simple(
     const int ncols_x = ncols;
     const scalar_t mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     auto cur = *(init + col);
-    const int d2 = d*2;
+    const int d2 = d * 2;
 
-    const auto wc1 = *(weight_c + (col%d2));
-    const auto wc2 = *(weight_c + (col%d2) + d2);
+    const auto wc1 = *(weight_c + (col % d2));
+    const auto wc2 = *(weight_c + (col % d2) + d2);
 
-    const auto bias1 = *(bias + (col%d2));
-    const auto bias2 = *(bias + (col%d2) + d2);
+    const auto bias1 = *(bias + (col % d2));
+    const auto bias2 = *(bias + (col % d2) + d2);
 
     const auto *up = u + (col * 3);
     const auto *xp = x + col;
-    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d2));
     auto *cp = c + col;
     auto *hp = h + col;
-    const bool flip = (col%d2) >= d;
+    const bool flip = (col % d2) >= d;
     if (flip) {
-        up += (len-1)*ncols_u;
-        cp += (len-1)*ncols;
-        hp += (len-1)*ncols;
-        xp += (len-1)*ncols_x;
-        if (pad_p) pad_p += (len-1)*batch;
+        up += (len - 1) * ncols_u;
+        cp += (len - 1) * ncols;
+        hp += (len - 1) * ncols;
+        xp += (len - 1) * ncols_x;
+        if (pad_p) pad_p += (len - 1) * batch;
     }
     const int ncols_u_ = flip ? -ncols_u : ncols_u;
     const int ncols_x_ = flip ? -ncols_x : ncols_x;
     const int ncols_ = flip ? -ncols : ncols;
     const int batch_ = flip ? -batch : batch;
 
-    for (int cnt = 0; cnt < len; ++cnt)
-    {
+    for (int cnt = 0; cnt < len; ++cnt) {
         if ((pad_p == NULL) || !(*pad_p)) {
             const auto u0 = *up;
             const auto u1 = *(up + 1);
             const auto u2 = *(up + 2);
 
             const auto x_val = *xp;
-            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
-            cur = (cur-u0)*g1 + u0;
+            const auto g1 = sigmoidf(u1 + wc1 * cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * cur + bias2);
+            cur = (cur - u0) * g1 + u0;
             *hp = (cur - x_val) * mask * g2 + x_val;
         } 
-        //else {
-        //    *hp = 0;  // ouptut 0 for a pad token
-        //}
         *cp = cur;  // useful for backward
         up += ncols_u_;
         cp += ncols_;
@@ -288,7 +275,7 @@ __global__ void sru_cuda_bi_backward_kernel_simple(
                            const int batch,
                            const int d)
 {
-    int ncols = batch*d*2;
+    int ncols = batch * d * 2;
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
@@ -300,41 +287,40 @@ __global__ void sru_cuda_bi_backward_kernel_simple(
     scalar_t gbias1 = 0;
     scalar_t gbias2 = 0;
     auto cur = *(grad_last + col);
-    const int d2 = d*2;
+    const int d2 = d * 2;
 
-    const auto wc1 = *(weight_c + (col%d2));
-    const auto wc2 = *(weight_c + (col%d2) + d2);
+    const auto wc1 = *(weight_c + (col % d2));
+    const auto wc2 = *(weight_c + (col % d2) + d2);
 
-    const auto bias1 = *(bias + (col%d2));
-    const auto bias2 = *(bias + (col%d2) + d2);
+    const auto bias1 = *(bias + (col % d2));
+    const auto bias2 = *(bias + (col % d2) + d2);
 
     const auto *up = u + (col * 3);
     const auto *xp = x + col;
     const auto *cp = c + col;
     const auto *ghp = grad_h + col;
-    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d2));
     auto *gup = grad_u + (col * 3);
     auto *gxp = grad_x + col;
 
-    const bool flip = ((col%d2) >= d);
+    const bool flip = ((col % d2) >= d);
     if (!flip) {
-        up += (len-1)*ncols_u;
-        cp += (len-1)*ncols;
-        ghp += (len-1)*ncols;
-        gup += (len-1)*ncols_u;
-        xp += (len-1)*ncols_x;
-        gxp += (len-1)*ncols_x;
-        if (pad_p) pad_p += (len-1)*batch;
+        up += (len - 1) * ncols_u;
+        cp += (len - 1) * ncols;
+        ghp += (len - 1) * ncols;
+        gup += (len - 1) * ncols_u;
+        xp += (len - 1) * ncols_x;
+        gxp += (len - 1) * ncols_x;
+        if (pad_p) pad_p += (len - 1) * batch;
     }
     const int ncols_u_ = flip ? -ncols_u : ncols_u;
     const int ncols_x_ = flip ? -ncols_x : ncols_x;
     const int ncols_ = flip ? -ncols : ncols;
     const int batch_ = flip ? -batch : batch;
 
-    for (int cnt = 0; cnt < len; ++cnt)
-    {
+    for (int cnt = 0; cnt < len; ++cnt) {
         if ((pad_p == NULL) || !(*pad_p)) {
-            const auto prev_c_val = (cnt<len-1) ? (*(cp-ncols_)) : (*(init+col));
+            const auto prev_c_val = (cnt < len - 1) ? (*(cp - ncols_)) : (*(init + col));
             const auto c_val = *cp;
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -342,35 +328,35 @@ __global__ void sru_cuda_bi_backward_kernel_simple(
 
             const auto x_val = *xp;
             const auto gh_val = *ghp;
-            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+            const auto g1 = sigmoidf(u1 + wc1 * prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * prev_c_val + bias2);
 
             // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
             // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + u0
 
             // gradient with respect to values in the second gate g2
-            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            const auto gg2 = gh_val * (c_val - x_val) * mask * (g2 * (1.f - g2));
             gbias2 += gg2;
-            gwc2 += gg2*prev_c_val;
+            gwc2 += gg2 * prev_c_val;
 
             // gradient with respect to c[t]
             const auto gc = gh_val * mask * g2 + cur;
 
             // gradient with respect to values in the first gate g1
-            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            const auto gg1 = gc * (prev_c_val - u0) * (g1 * (1.f - g1));
             gbias1 += gg1;
-            gwc1 += gg1*prev_c_val;
+            gwc1 += gg1 * prev_c_val;
 
             // gradient with respect to c[t-1]
-            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+            cur = gc * g1 + gg1 * wc1 + gg2 * wc2;
 
             // gradient with respect to U
-            *gup = gc*(1.f-g1);
+            *gup = gc * (1.f - g1);
             *(gup + 1) = gg1;
             *(gup + 2) = gg2;
 
             // gradient with respect to x[t]
-            *gxp = gh_val*(1.f-g2*mask);
+            *gxp = gh_val * (1.f - g2 * mask);
         }
 
         up -= ncols_u_;
@@ -382,11 +368,6 @@ __global__ void sru_cuda_bi_backward_kernel_simple(
         pad_p = mask_pad ? (pad_p - batch_) : NULL;
     }
 
-    //const int bias_idx = col % d2;
-    //atomicAdd(grad_wc + bias_idx, gwc1);
-    //atomicAdd(grad_wc + bias_idx + d2, gwc2);
-    //atomicAdd(grad_bias + bias_idx, gbias1);
-    //atomicAdd(grad_bias + bias_idx + d2, gbias2);
     *(grad_wc + col) = gwc1;
     *(grad_wc + col + ncols) = gwc2;
     *(grad_bias + col) = gbias1;
@@ -417,28 +398,27 @@ __global__ void sru_cuda_forward_kernel(
     assert ((skip_type != 1) || (k == 3));
     assert ((skip_type != 2) || (k == 4));
 
-    const int ncols = batch*d;
+    const int ncols = batch * d;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
-    const int ncols_u = ncols*k;
+    const int ncols_u = ncols * k;
     const int ncols_x = (k == 3) ? ncols : ncols_u;
 
-    const auto* vp1 = is_custom ? (weight_c + col*2) : (weight_c + (col%d));
-    const auto* vp2 = is_custom ? (weight_c + col*2 + 1) : (weight_c + (col%d) + d);
+    const auto* vp1 = is_custom ? (weight_c + col * 2) : (weight_c + (col % d));
+    const auto* vp2 = is_custom ? (weight_c + col * 2 + 1) : (weight_c + (col % d) + d);
 
-    const auto bias1 = *(bias + (col%d));
-    const auto bias2 = *(bias + (col%d) + d);
+    const auto bias1 = *(bias + (col % d));
+    const auto bias2 = *(bias + (col % d) + d);
     const auto  mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     auto cur = *(init + col);
-    const auto* up = u + (col*k);
+    const auto* up = u + (col * k);
     const auto* xp = (skip_type == 0) ? NULL : ((skip_type == 1) ? (x + col) : (up + 3));
-    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d));
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d));
     auto* cp = c + col;
     auto* hp = h + col;
 
-    for (int row = 0; row < len; ++row)
-    {
+    for (int row = 0; row < len; ++row) {
         if ((pad_p == NULL) || !(*pad_p)) {
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -447,15 +427,12 @@ __global__ void sru_cuda_forward_kernel(
             const auto wc2 = *vp2;
 
             const auto x_val = (skip_type) ? (*xp) : (scalar_t)0.f;
-            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
-            cur = (cur-u0)*g1 + u0;
+            const auto g1 = sigmoidf(u1 + wc1 * cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * cur + bias2);
+            cur = (cur - u0) * g1 + u0;
             const auto val = calc_activation(activation_type, cur);
             *hp = skip_type ? ((val - x_val) * mask * g2 + x_val) : (val * mask * g2);
         } 
-        //else {
-        //    *hp = 0;  // output 0 for a pad token
-        //}
         *cp = cur;  // useful for backward
         up += ncols_u;
         cp += ncols;
@@ -496,20 +473,20 @@ __global__ void sru_cuda_backward_kernel(
     assert ((skip_type != 1) || (k == 3));
     assert ((skip_type != 2) || (k == 4));
 
-    const int ncols = batch*d;
+    const int ncols = batch * d;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
-    const int ncols_u = ncols*k;
+    const int ncols_u = ncols * k;
     const int ncols_x = (k == 3) ? ncols : ncols_u;
 
-    const auto* vp1 = is_custom ? (weight_c + col*2 + (len-1)*ncols*2) : (weight_c + (col%d));
-    const auto* vp2 = is_custom ? (weight_c + col*2 + 1 + (len-1)*ncols*2) : (weight_c + (col%d) + d);
-    auto* gvp1 = is_custom ? (grad_wc + col*2 + (len-1)*ncols*2) : (grad_wc + col);
-    auto* gvp2 = is_custom ? (grad_wc + col*2 + 1 + (len-1)*ncols*2) : (grad_wc + col + ncols);
+    const auto* vp1 = is_custom ? (weight_c + col * 2 + (len - 1) * ncols * 2) : (weight_c + (col % d));
+    const auto* vp2 = is_custom ? (weight_c + col * 2 + 1 + (len - 1) * ncols * 2) : (weight_c + (col % d) + d);
+    auto* gvp1 = is_custom ? (grad_wc + col * 2 + (len - 1) * ncols * 2) : (grad_wc + col);
+    auto* gvp2 = is_custom ? (grad_wc + col * 2 + 1 + (len - 1) * ncols * 2) : (grad_wc + col + ncols);
 
-    const auto bias1 = *(bias + (col%d));
-    const auto bias2 = *(bias + (col%d) + d);
+    const auto bias1 = *(bias + (col % d));
+    const auto bias2 = *(bias + (col % d) + d);
     const auto mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     scalar_t gwc1 = 0;
     scalar_t gwc2 = 0;
@@ -517,22 +494,22 @@ __global__ void sru_cuda_backward_kernel(
     scalar_t gbias2 = 0;
     auto cur = *(grad_last + col);
 
-    const auto* up = u + (col*k) + (len-1)*ncols_u;
+    const auto* up = u + (col * k) + (len - 1) * ncols_u;
     const auto* xp = (skip_type == 0) ? NULL : (
-        (skip_type == 1) ? (x + col + (len-1)*ncols) : (up + 3)
+        (skip_type == 1) ? (x + col + (len - 1) * ncols) : (up + 3)
     );
-    const auto* cp = c + col + (len-1)*ncols;
-    const auto* ghp = grad_h + col + (len-1)*ncols;
-    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d) + (len-1)*batch);
-    auto* gup = grad_u + (col*k) + (len-1)*ncols_u;
+    const auto* cp = c + col + (len - 1) * ncols;
+    const auto* ghp = grad_h + col + (len - 1) * ncols;
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL :
+                                 (mask_pad + (col / d) + (len - 1) * batch);
+    auto* gup = grad_u + (col * k) + (len - 1) * ncols_u;
     auto* gxp = (skip_type == 0) ? NULL : (
-        (skip_type == 1) ? (grad_x + col + (len-1)*ncols) : (gup + 3)
+        (skip_type == 1) ? (grad_x + col + (len - 1) * ncols) : (gup + 3)
     );
 
-    for (int row = len-1; row >= 0; --row)
-    {
+    for (int row = len-1; row >= 0; --row) {
         if ((pad_p == NULL) || !(*pad_p)) {
-            const auto prev_c_val = (row>0) ? (*(cp-ncols)) : (*(init+col));
+            const auto prev_c_val = (row > 0) ? (*(cp - ncols)) : (*(init + col));
             const auto cp_val = *cp;
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -542,40 +519,40 @@ __global__ void sru_cuda_backward_kernel(
 
             const auto x_val = (skip_type) ? (*xp) : (scalar_t)0.f;
             const auto gh_val = *ghp;
-            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+            const auto g1 = sigmoidf(u1 + wc1 * prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * prev_c_val + bias2);
             const auto c_val = calc_activation(activation_type, cp_val);
 
             // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
             // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + g0
 
             // gradient with respect to values in the second gate g2
-            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            const auto gg2 = gh_val * (c_val - x_val) * mask * (g2 * (1.f - g2));
             gbias2 += gg2;
-            gwc2 += gg2*prev_c_val;
-            *gvp2 = gg2*prev_c_val;
+            gwc2 += gg2 * prev_c_val;
+            *gvp2 = gg2 * prev_c_val;
 
             // gradient with respect to c[t]
-            const auto tmp = g2*calc_grad_activation(activation_type, c_val);
-            const auto gc = gh_val*mask*tmp + cur;
+            const auto tmp = g2 * calc_grad_activation(activation_type, c_val);
+            const auto gc = gh_val * mask * tmp + cur;
 
             // gradient with respect to values in the first gate g1
-            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            const auto gg1 = gc * (prev_c_val - u0) * (g1 * (1.f - g1));
             gbias1 += gg1;
-            gwc1 += gg1*prev_c_val;
-            *gvp1 = gg1*prev_c_val;
+            gwc1 += gg1 * prev_c_val;
+            *gvp1 = gg1 * prev_c_val;
 
             // gradient with respect to c[t-1]
-            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+            cur = gc * g1 + gg1 * wc1 + gg2 * wc2;
 
             // gradient with respect to U
-            *gup = gc*(1.f-g1);
+            *gup = gc * (1.f - g1);
             *(gup + 1) = gg1;
             *(gup + 2) = gg2;
  
             // gradient with respect to x[t]
             if (skip_type)
-                *gxp = gh_val*(1.f-g2*mask);
+                *gxp = gh_val * (1.f - g2 * mask);
         }
 
         up -= ncols_u;
@@ -591,11 +568,6 @@ __global__ void sru_cuda_backward_kernel(
         gvp2 = is_custom ? (gvp2 - ncols*2) : gvp2;
     }
 
-    //const int bias_idx = col % d;
-    //atomicAdd(grad_wc + bias_idx, gwc1);
-    //atomicAdd(grad_wc + bias_idx + d, gwc2);
-    //atomicAdd(grad_bias + bias_idx, gbias1);
-    //atomicAdd(grad_bias + bias_idx + d, gbias2);
     if (!is_custom) {
         *(grad_wc + col) = gwc1;
         *(grad_wc + col + ncols) = gwc2;
@@ -628,37 +600,37 @@ __global__ void sru_cuda_bi_forward_kernel(
     assert ((skip_type != 1) || (k == 3));
     assert ((skip_type != 2) || (k == 4));
 
-    const int ncols = batch*d*2;
+    const int ncols = batch * d * 2;
     const int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
-    const int ncols_u = ncols*k;
+    const int ncols_u = ncols * k;
     const int ncols_x = (k == 3) ? ncols : ncols_u;
     const scalar_t mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     auto cur = *(init + col);
-    const int d2 = d*2;
+    const int d2 = d * 2;
 
-    const auto* vp1 = is_custom ? (weight_c + col*2) : (weight_c + (col%d2));
-    const auto* vp2 = is_custom ? (weight_c + col*2 + 1) : (weight_c + (col%d2) + d2);
+    const auto* vp1 = is_custom ? (weight_c + col * 2) : (weight_c + (col % d2));
+    const auto* vp2 = is_custom ? (weight_c + col * 2 + 1) : (weight_c + (col % d2) + d2);
 
-    const auto bias1 = *(bias + (col%d2));
-    const auto bias2 = *(bias + (col%d2) + d2);
+    const auto bias1 = *(bias + (col % d2));
+    const auto bias2 = *(bias + (col % d2) + d2);
 
-    const auto *up = u + (col*k);
+    const auto *up = u + (col * k);
     const auto *xp = (skip_type == 0) ? NULL : ((skip_type == 1) ? (x + col) : (up + 3));
-    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d2));
     auto *cp = c + col;
     auto *hp = h + col;
-    const bool flip = (col%d2) >= d;
+    const bool flip = (col % d2) >= d;
     if (flip) {
-        up += (len-1)*ncols_u;
-        cp += (len-1)*ncols;
-        hp += (len-1)*ncols;
-        if (skip_type) xp += (len-1)*ncols_x;
-        if (pad_p) pad_p += (len-1)*batch;
+        up += (len - 1) * ncols_u;
+        cp += (len - 1) * ncols;
+        hp += (len - 1) * ncols;
+        if (skip_type) xp += (len - 1) * ncols_x;
+        if (pad_p) pad_p += (len - 1) * batch;
         if (is_custom) {
-            vp1 += (len-1)*ncols*2;
-            vp2 += (len-1)*ncols*2;
+            vp1 += (len - 1) * ncols * 2;
+            vp2 += (len - 1) * ncols * 2;
         }
     }
     const int ncols_u_ = flip ? -ncols_u : ncols_u;
@@ -666,8 +638,7 @@ __global__ void sru_cuda_bi_forward_kernel(
     const int ncols_ = flip ? -ncols : ncols;
     const int batch_ = flip ? -batch : batch;
 
-    for (int cnt = 0; cnt < len; ++cnt)
-    {
+    for (int cnt = 0; cnt < len; ++cnt) {
         if ((pad_p == NULL) || !(*pad_p)) {
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -676,23 +647,20 @@ __global__ void sru_cuda_bi_forward_kernel(
             const auto wc2 = *vp2;
 
             const auto x_val = (skip_type) ? (*xp) : (scalar_t)0.f;
-            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
-            cur = (cur-u0)*g1 + u0;
+            const auto g1 = sigmoidf(u1 + wc1 * cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * cur + bias2);
+            cur = (cur - u0) * g1 + u0;
             const auto val = calc_activation(activation_type, cur);
             *hp = skip_type ? ((val - x_val) * mask * g2 + x_val) : (val * mask * g2);
         } 
-        //else {
-        //    *hp = 0;  // ouptut 0 for a pad token
-        //}
         *cp = cur;  // useful for backward
         up += ncols_u_;
         cp += ncols_;
         hp += ncols_;
         xp = skip_type ? (xp + ncols_x_) : NULL;
         pad_p = mask_pad ? (pad_p + batch_) : NULL;
-        vp1 = is_custom ? (vp1 + ncols_*2) : vp1;
-        vp2 = is_custom ? (vp2 + ncols_*2) : vp2;
+        vp1 = is_custom ? (vp1 + ncols_ * 2) : vp1;
+        vp2 = is_custom ? (vp2 + ncols_ * 2) : vp2;
     }
 }
 
@@ -725,11 +693,11 @@ __global__ void sru_cuda_bi_backward_kernel(
     assert ((skip_type != 1) || (k == 3));
     assert ((skip_type != 2) || (k == 4));
 
-    int ncols = batch*d*2;
+    int ncols = batch * d * 2;
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col >= ncols) return;
 
-    int ncols_u = ncols*k;
+    int ncols_u = ncols * k;
     int ncols_x = (k == 3) ? ncols : ncols_u;
     const scalar_t mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
     scalar_t gwc1 = 0;
@@ -737,44 +705,44 @@ __global__ void sru_cuda_bi_backward_kernel(
     scalar_t gbias1 = 0;
     scalar_t gbias2 = 0;
     auto cur = *(grad_last + col);
-    const int d2 = d*2;
+    const int d2 = d * 2;
 
-    const auto* vp1 = is_custom ? (weight_c + col*2) : (weight_c + (col%d2));
-    const auto* vp2 = is_custom ? (weight_c + col*2 + 1) : (weight_c + (col%d2) + d2);
-    auto* gvp1 = is_custom ? (grad_wc + col*2) : (grad_wc + col);
-    auto* gvp2 = is_custom ? (grad_wc + col*2 + 1) : (grad_wc + col + ncols);
+    const auto* vp1 = is_custom ? (weight_c + col * 2) : (weight_c + (col % d2));
+    const auto* vp2 = is_custom ? (weight_c + col * 2 + 1) : (weight_c + (col % d2) + d2);
+    auto* gvp1 = is_custom ? (grad_wc + col * 2) : (grad_wc + col);
+    auto* gvp2 = is_custom ? (grad_wc + col * 2 + 1) : (grad_wc + col + ncols);
 
-    const auto bias1 = *(bias + (col%d2));
-    const auto bias2 = *(bias + (col%d2) + d2);
+    const auto bias1 = *(bias + (col % d2));
+    const auto bias2 = *(bias + (col % d2) + d2);
 
-    const auto *up = u + (col*k);
+    const auto *up = u + (col * k);
     const auto *xp = (skip_type == 0) ? NULL : (
         (skip_type == 1) ? (x + col) : (up + 3)
     );
     const auto *cp = c + col;
     const auto *ghp = grad_h + col;
-    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
-    auto *gup = grad_u + (col*k);
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col / d2));
+    auto *gup = grad_u + (col * k);
     auto *gxp = (skip_type == 0) ? NULL : (
         (skip_type == 1) ? (grad_x + col) : (gup + 3)
     );
 
-    const bool flip = ((col%d2) >= d);
+    const bool flip = ((col % d2) >= d);
     if (!flip) {
-        up += (len-1)*ncols_u;
-        cp += (len-1)*ncols;
-        ghp += (len-1)*ncols;
-        gup += (len-1)*ncols_u;
+        up += (len - 1) * ncols_u;
+        cp += (len - 1) * ncols;
+        ghp += (len - 1) * ncols;
+        gup += (len - 1) * ncols_u;
         if (skip_type) {
-            xp += (len-1)*ncols_x;
-            gxp += (len-1)*ncols_x;
+            xp += (len - 1) * ncols_x;
+            gxp += (len - 1) * ncols_x;
         }
-        if (pad_p) pad_p += (len-1)*batch;
+        if (pad_p) pad_p += (len - 1) * batch;
         if (is_custom) {
-            vp1 += (len-1)*ncols*2;
-            vp2 += (len-1)*ncols*2;
-            gvp1 += (len-1)*ncols*2;
-            gvp2 += (len-1)*ncols*2;
+            vp1 += (len - 1) * ncols * 2;
+            vp2 += (len - 1) * ncols * 2;
+            gvp1 += (len - 1) * ncols * 2;
+            gvp2 += (len - 1) * ncols * 2;
         }
     }
     const int ncols_u_ = flip ? -ncols_u : ncols_u;
@@ -785,7 +753,7 @@ __global__ void sru_cuda_bi_backward_kernel(
     for (int cnt = 0; cnt < len; ++cnt)
     {
         if ((pad_p == NULL) || !(*pad_p)) {
-            const auto prev_c_val = (cnt<len-1) ? (*(cp-ncols_)) : (*(init+col));
+            const auto prev_c_val = (cnt < len - 1) ? (*(cp - ncols_)) : (*(init + col));
             const auto cp_val = *cp;
             const auto u0 = *up;
             const auto u1 = *(up + 1);
@@ -795,40 +763,40 @@ __global__ void sru_cuda_bi_backward_kernel(
 
             const auto x_val = (skip_type) ? (*xp) : (scalar_t)0.f;
             const auto gh_val = *ghp;
-            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
-            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+            const auto g1 = sigmoidf(u1 + wc1 * prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2 * prev_c_val + bias2);
             const auto c_val = calc_activation(activation_type, cp_val);
 
             // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
             // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + u0
 
             // gradient with respect to values in the second gate g2
-            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            const auto gg2 = gh_val * (c_val - x_val) * mask * (g2 * (1.f - g2));
             gbias2 += gg2;
-            gwc2 += gg2*prev_c_val;
-            *gvp2 = gg2*prev_c_val;
+            gwc2 += gg2 * prev_c_val;
+            *gvp2 = gg2 * prev_c_val;
 
             // gradient with respect to c[t]
-            const auto tmp = g2*calc_grad_activation(activation_type, c_val);
-            const auto gc = gh_val*mask*tmp + cur;
+            const auto tmp = g2 * calc_grad_activation(activation_type, c_val);
+            const auto gc = gh_val * mask * tmp + cur;
 
             // gradient with respect to values in the first gate g1
-            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            const auto gg1 = gc * (prev_c_val - u0) * (g1 * (1.f - g1));
             gbias1 += gg1;
-            gwc1 += gg1*prev_c_val;
-            *gvp1 = gg1*prev_c_val;
+            gwc1 += gg1 * prev_c_val;
+            *gvp1 = gg1 * prev_c_val;
 
             // gradient with respect to c[t-1]
-            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+            cur = gc * g1 + gg1 * wc1 + gg2 * wc2;
 
             // gradient with respect to U
-            *gup = gc*(1.f-g1);
+            *gup = gc * (1.f - g1);
             *(gup + 1) = gg1;
             *(gup + 2) = gg2;
 
             // gradient with respect to x[t]
             if (skip_type)
-                *gxp = gh_val*(1.f-g2*mask);
+                *gxp = gh_val * (1.f - g2 * mask);
         }
 
         up -= ncols_u_;
@@ -838,17 +806,12 @@ __global__ void sru_cuda_bi_backward_kernel(
         xp = skip_type ? (xp - ncols_x_) : NULL;
         gxp = skip_type ? (gxp - ncols_x_) : NULL;
         pad_p = mask_pad ? (pad_p - batch_) : NULL;
-        vp1 = is_custom ? (vp1 - ncols_*2) : vp1;
-        vp2 = is_custom ? (vp2 - ncols_*2) : vp2;
-        gvp1 = is_custom ? (gvp1 - ncols_*2) : gvp1;
-        gvp2 = is_custom ? (gvp2 - ncols_*2) : gvp2;
+        vp1 = is_custom ? (vp1 - ncols_ * 2) : vp1;
+        vp2 = is_custom ? (vp2 - ncols_ * 2) : vp2;
+        gvp1 = is_custom ? (gvp1 - ncols_ * 2) : gvp1;
+        gvp2 = is_custom ? (gvp2 - ncols_ * 2) : gvp2;
     }
 
-    //const int bias_idx = col % d2;
-    //atomicAdd(grad_wc + bias_idx, gwc1);
-    //atomicAdd(grad_wc + bias_idx + d2, gwc2);
-    //atomicAdd(grad_bias + bias_idx, gbias1);
-    //atomicAdd(grad_bias + bias_idx + d2, gbias2);
     if (!is_custom) {
         *(grad_wc + col) = gwc1;
         *(grad_wc + col + ncols) = gwc2;

--- a/sru/csrc/sru_cuda_kernel.cu
+++ b/sru/csrc/sru_cuda_kernel.cu
@@ -23,6 +23,378 @@ __forceinline__ __device__ scalar_t calc_grad_activation(int type, scalar_t x)
 }
 
 template <typename scalar_t>
+__global__ void sru_cuda_forward_kernel_simple(
+                        scalar_t* __restrict__ h,
+                        scalar_t* __restrict__ c,
+                        const scalar_t* __restrict__ u,
+                        const scalar_t* __restrict__ x,
+                        const scalar_t* __restrict__ weight_c,
+                        const scalar_t* __restrict__ bias,
+                        const scalar_t* __restrict__ init,
+                        const scalar_t* __restrict__ mask_c,
+                        const unsigned char* __restrict__ mask_pad,
+                        const int len,
+                        const int batch,
+                        const int d)
+{
+    const int ncols = batch*d;
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    if (col >= ncols) return;
+
+    const int ncols_u = ncols * 3;
+    const int ncols_x = ncols;
+
+    const auto wc1 = *(weight_c + (col%d));
+    const auto wc2 = *(weight_c + (col%d) + d);
+
+    const auto bias1 = *(bias + (col%d));
+    const auto bias2 = *(bias + (col%d) + d);
+    const auto  mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
+    auto cur = *(init + col);
+    const auto* up = u + (col * 3);
+    const auto* xp = x + col;
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d));
+    auto* cp = c + col;
+    auto* hp = h + col;
+
+    for (int row = 0; row < len; ++row)
+    {
+        if ((pad_p == NULL) || !(*pad_p)) {
+            const auto u0 = *up;
+            const auto u1 = *(up + 1);
+            const auto u2 = *(up + 2);
+
+            const auto x_val = *xp;
+            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
+            cur = (cur-u0)*g1 + u0;
+            *hp = (cur - x_val) * mask * g2 + x_val;
+        } 
+        //else {
+        //    *hp = 0;  // output 0 for a pad token
+        //}
+        *cp = cur;  // useful for backward
+        up += ncols_u;
+        cp += ncols;
+        hp += ncols;
+        xp += ncols_x;
+        pad_p = mask_pad ? (pad_p + batch) : NULL;
+    }
+}
+
+template <typename scalar_t>
+__global__ void sru_cuda_backward_kernel_simple(
+                        scalar_t* __restrict__ grad_u,
+                        scalar_t* __restrict__ grad_x,
+                        scalar_t* __restrict__ grad_wc,
+                        scalar_t* __restrict__ grad_bias,
+                        scalar_t* __restrict__ grad_init,
+                        const scalar_t* __restrict__ u,
+                        const scalar_t* __restrict__ x,
+                        const scalar_t* __restrict__ weight_c,
+                        const scalar_t* __restrict__ bias,
+                        const scalar_t* __restrict__ init,
+                        const scalar_t* __restrict__ mask_c,
+                        const unsigned char * __restrict__ mask_pad,
+                        const scalar_t* __restrict__ c,
+                        const scalar_t* __restrict__ grad_h,
+                        const scalar_t* __restrict__ grad_last,
+                        const int len,
+                        const int batch,
+                        const int d)
+{
+    const int ncols = batch*d;
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    if (col >= ncols) return;
+
+    const int ncols_u = ncols * 3;
+    const int ncols_x = ncols;
+
+    const auto wc1 = *(weight_c + (col%d));
+    const auto wc2 = *(weight_c + (col%d) + d);
+
+    const auto bias1 = *(bias + (col%d));
+    const auto bias2 = *(bias + (col%d) + d);
+    const auto mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
+    scalar_t gwc1 = 0;
+    scalar_t gwc2 = 0;
+    scalar_t gbias1 = 0;
+    scalar_t gbias2 = 0;
+    auto cur = *(grad_last + col);
+
+    const auto* up = u + (col * 3) + (len-1)*ncols_u;
+    const auto* xp = x + col + (len-1)*ncols;
+    const auto* cp = c + col + (len-1)*ncols;
+    const auto* ghp = grad_h + col + (len-1)*ncols;
+    const unsigned char* pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d) + (len-1)*batch);
+    auto* gup = grad_u + (col * 3) + (len-1)*ncols_u;
+    auto* gxp = grad_x + col + (len-1)*ncols;
+
+    for (int row = len-1; row >= 0; --row)
+    {
+        if ((pad_p == NULL) || !(*pad_p)) {
+            const auto prev_c_val = row ? (*(cp-ncols)) : (*(init+col));
+            const auto c_val = *cp;
+            const auto u0 = *up;
+            const auto u1 = *(up + 1);
+            const auto u2 = *(up + 2);
+
+            const auto x_val = *xp;
+            const auto gh_val = *ghp;
+            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+
+            // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
+            // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + g0
+
+            // gradient with respect to values in the second gate g2
+            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            gbias2 += gg2;
+            gwc2 += gg2*prev_c_val;
+
+            // gradient with respect to c[t]
+            const auto gc = gh_val * mask * g2 + cur;
+
+            // gradient with respect to values in the first gate g1
+            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            gbias1 += gg1;
+            gwc1 += gg1*prev_c_val;
+
+            // gradient with respect to c[t-1]
+            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+
+            // gradient with respect to U
+            *gup = gc*(1.f-g1);
+            *(gup + 1) = gg1;
+            *(gup + 2) = gg2;
+ 
+            // gradient with respect to x[t]
+            *gxp = gh_val*(1.f-g2*mask);
+        }
+
+        up -= ncols_u;
+        cp -= ncols;
+        gup -= ncols_u;
+        ghp -= ncols;
+        xp -= ncols_x;
+        gxp -= ncols_x;
+        pad_p = mask_pad ? (pad_p - batch) : NULL;
+    }
+
+    //const int bias_idx = col % d;
+    //atomicAdd(grad_wc + bias_idx, gwc1);
+    //atomicAdd(grad_wc + bias_idx + d, gwc2);
+    //atomicAdd(grad_bias + bias_idx, gbias1);
+    //atomicAdd(grad_bias + bias_idx + d, gbias2);
+    *(grad_wc + col) = gwc1;
+    *(grad_wc + col + ncols) = gwc2;
+    *(grad_bias + col) = gbias1;
+    *(grad_bias + col + ncols) = gbias2;
+    *(grad_init + col) = cur;
+}
+
+template <typename scalar_t>
+__global__ void sru_cuda_bi_forward_kernel_simple(
+                        scalar_t* __restrict__ h,
+                        scalar_t* __restrict__ c,
+                        const scalar_t* __restrict__ u,
+                        const scalar_t* __restrict__ x,
+                        const scalar_t* __restrict__ weight_c,
+                        const scalar_t* __restrict__ bias,
+                        const scalar_t* __restrict__ init,
+                        const scalar_t* __restrict__ mask_c,
+                        const unsigned char * __restrict__ mask_pad,
+                        const int len,
+                        const int batch,
+                        const int d)
+{
+    const int ncols = batch*d*2;
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    if (col >= ncols) return;
+
+    const int ncols_u = ncols * 3;
+    const int ncols_x = ncols;
+    const scalar_t mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
+    auto cur = *(init + col);
+    const int d2 = d*2;
+
+    const auto wc1 = *(weight_c + (col%d2));
+    const auto wc2 = *(weight_c + (col%d2) + d2);
+
+    const auto bias1 = *(bias + (col%d2));
+    const auto bias2 = *(bias + (col%d2) + d2);
+
+    const auto *up = u + (col * 3);
+    const auto *xp = x + col;
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
+    auto *cp = c + col;
+    auto *hp = h + col;
+    const bool flip = (col%d2) >= d;
+    if (flip) {
+        up += (len-1)*ncols_u;
+        cp += (len-1)*ncols;
+        hp += (len-1)*ncols;
+        xp += (len-1)*ncols_x;
+        if (pad_p) pad_p += (len-1)*batch;
+    }
+    const int ncols_u_ = flip ? -ncols_u : ncols_u;
+    const int ncols_x_ = flip ? -ncols_x : ncols_x;
+    const int ncols_ = flip ? -ncols : ncols;
+    const int batch_ = flip ? -batch : batch;
+
+    for (int cnt = 0; cnt < len; ++cnt)
+    {
+        if ((pad_p == NULL) || !(*pad_p)) {
+            const auto u0 = *up;
+            const auto u1 = *(up + 1);
+            const auto u2 = *(up + 2);
+
+            const auto x_val = *xp;
+            const auto g1 = sigmoidf(u1 + wc1*cur + bias1);
+            const auto g2 = sigmoidf(u2 + wc2*cur + bias2);
+            cur = (cur-u0)*g1 + u0;
+            *hp = (cur - x_val) * mask * g2 + x_val;
+        } 
+        //else {
+        //    *hp = 0;  // ouptut 0 for a pad token
+        //}
+        *cp = cur;  // useful for backward
+        up += ncols_u_;
+        cp += ncols_;
+        hp += ncols_;
+        xp += ncols_x_;
+        pad_p = mask_pad ? (pad_p + batch_) : NULL;
+    }
+}
+
+template <typename scalar_t>
+__global__ void sru_cuda_bi_backward_kernel_simple(
+                           scalar_t* __restrict__ grad_u,
+                           scalar_t* __restrict__ grad_x,
+                           scalar_t* __restrict__ grad_wc,
+                           scalar_t* __restrict__ grad_bias,
+                           scalar_t* __restrict__ grad_init,
+                           const scalar_t* __restrict__ u,
+                           const scalar_t* __restrict__ x,
+                           const scalar_t* __restrict__ weight_c,
+                           const scalar_t* __restrict__ bias,
+                           const scalar_t* __restrict__ init,
+                           const scalar_t* __restrict__ mask_c,
+                           const unsigned char * __restrict__ mask_pad,
+                           const scalar_t* __restrict__ c,
+                           const scalar_t* __restrict__ grad_h,
+                           const scalar_t* __restrict__ grad_last,
+                           const int len,
+                           const int batch,
+                           const int d)
+{
+    int ncols = batch*d*2;
+    int col = blockIdx.x * blockDim.x + threadIdx.x;
+    if (col >= ncols) return;
+
+    int ncols_u = ncols * 3;
+    int ncols_x = ncols;
+    const scalar_t mask = (mask_c == NULL) ? (scalar_t)1.f : (*(mask_c + col));
+    scalar_t gwc1 = 0;
+    scalar_t gwc2 = 0;
+    scalar_t gbias1 = 0;
+    scalar_t gbias2 = 0;
+    auto cur = *(grad_last + col);
+    const int d2 = d*2;
+
+    const auto wc1 = *(weight_c + (col%d2));
+    const auto wc2 = *(weight_c + (col%d2) + d2);
+
+    const auto bias1 = *(bias + (col%d2));
+    const auto bias2 = *(bias + (col%d2) + d2);
+
+    const auto *up = u + (col * 3);
+    const auto *xp = x + col;
+    const auto *cp = c + col;
+    const auto *ghp = grad_h + col;
+    const unsigned char *pad_p = (mask_pad == NULL) ? NULL : (mask_pad + (col/d2));
+    auto *gup = grad_u + (col * 3);
+    auto *gxp = grad_x + col;
+
+    const bool flip = ((col%d2) >= d);
+    if (!flip) {
+        up += (len-1)*ncols_u;
+        cp += (len-1)*ncols;
+        ghp += (len-1)*ncols;
+        gup += (len-1)*ncols_u;
+        xp += (len-1)*ncols_x;
+        gxp += (len-1)*ncols_x;
+        if (pad_p) pad_p += (len-1)*batch;
+    }
+    const int ncols_u_ = flip ? -ncols_u : ncols_u;
+    const int ncols_x_ = flip ? -ncols_x : ncols_x;
+    const int ncols_ = flip ? -ncols : ncols;
+    const int batch_ = flip ? -batch : batch;
+
+    for (int cnt = 0; cnt < len; ++cnt)
+    {
+        if ((pad_p == NULL) || !(*pad_p)) {
+            const auto prev_c_val = (cnt<len-1) ? (*(cp-ncols_)) : (*(init+col));
+            const auto c_val = *cp;
+            const auto u0 = *up;
+            const auto u1 = *(up + 1);
+            const auto u2 = *(up + 2);
+
+            const auto x_val = *xp;
+            const auto gh_val = *ghp;
+            const auto g1 = sigmoidf(u1 + wc1*prev_c_val + bias1);
+            const auto g2 = sigmoidf(u2 + wc2*prev_c_val + bias2);
+
+            // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
+            // c = c'*g1 + u0*(1-g1) = (c'-u0)*g1 + u0
+
+            // gradient with respect to values in the second gate g2
+            const auto gg2 = gh_val*(c_val-x_val)*mask*(g2*(1.f-g2));
+            gbias2 += gg2;
+            gwc2 += gg2*prev_c_val;
+
+            // gradient with respect to c[t]
+            const auto gc = gh_val * mask * g2 + cur;
+
+            // gradient with respect to values in the first gate g1
+            const auto gg1 = gc*(prev_c_val-u0)*(g1*(1.f-g1));
+            gbias1 += gg1;
+            gwc1 += gg1*prev_c_val;
+
+            // gradient with respect to c[t-1]
+            cur = gc*g1 + gg1*wc1 + gg2*wc2;
+
+            // gradient with respect to U
+            *gup = gc*(1.f-g1);
+            *(gup + 1) = gg1;
+            *(gup + 2) = gg2;
+
+            // gradient with respect to x[t]
+            *gxp = gh_val*(1.f-g2*mask);
+        }
+
+        up -= ncols_u_;
+        cp -= ncols_;
+        gup -= ncols_u_;
+        ghp -= ncols_;
+        xp -= ncols_x_;
+        gxp -= ncols_x_;
+        pad_p = mask_pad ? (pad_p - batch_) : NULL;
+    }
+
+    //const int bias_idx = col % d2;
+    //atomicAdd(grad_wc + bias_idx, gwc1);
+    //atomicAdd(grad_wc + bias_idx + d2, gwc2);
+    //atomicAdd(grad_bias + bias_idx, gbias1);
+    //atomicAdd(grad_bias + bias_idx + d2, gbias2);
+    *(grad_wc + col) = gwc1;
+    *(grad_wc + col + ncols) = gwc2;
+    *(grad_bias + col) = gbias1;
+    *(grad_bias + col + ncols) = gbias2;
+    *(grad_init +col) = cur;
+}
+
+template <typename scalar_t>
 __global__ void sru_cuda_forward_kernel(
                         scalar_t* __restrict__ h,
                         scalar_t* __restrict__ c,
@@ -487,6 +859,174 @@ __global__ void sru_cuda_bi_backward_kernel(
 }
 
 } //  end of namespace
+
+//  unidirectional forward()
+void sru_cuda_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    const int threads = 512;
+    const int total = batch_size * hidden_size;
+    const dim3 blocks( (total - 1) / threads + 1 );
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(U.type(), "sru_forward_cuda_simple", ([&] {
+        sru_cuda_forward_kernel_simple<scalar_t><<<blocks, threads>>>(
+            h.data<scalar_t>(),
+            c.data<scalar_t>(),
+            U.data<scalar_t>(),
+            x.numel() ? x.data<scalar_t>() : NULL,
+            weight_c.data<scalar_t>(),
+            bias.data<scalar_t>(),
+            c_init.data<scalar_t>(),
+            mask_c.numel() ? mask_c.data<scalar_t>() : NULL,
+            mask_pad.numel() ? mask_pad.data<unsigned char>() : NULL,
+            length,
+            batch_size,
+            hidden_size);
+    }));
+}
+
+//  unidirectional backward()
+void sru_cuda_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    const int threads = 512;
+    const int total = batch_size * hidden_size;
+    const dim3 blocks( (total - 1) / threads + 1 );
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(U.type(), "sru_backward_cuda_simple", ([&] {
+        sru_cuda_backward_kernel_simple<scalar_t><<<blocks, threads>>>(
+            grad_u.data<scalar_t>(),
+            grad_x.numel() ? grad_x.data<scalar_t>() : NULL,
+            grad_wc.data<scalar_t>(),
+            grad_bias.data<scalar_t>(),
+            grad_init.data<scalar_t>(),
+            U.data<scalar_t>(),
+            x.numel() ? x.data<scalar_t>() : NULL,
+            weight_c.data<scalar_t>(),
+            bias.data<scalar_t>(),
+            c_init.data<scalar_t>(),
+            mask_c.numel() ? mask_c.data<scalar_t>() : NULL,
+            mask_pad.numel() ? mask_pad.data<unsigned char>() : NULL,
+            c.data<scalar_t>(),
+            grad_h.data<scalar_t>(),
+            grad_last.data<scalar_t>(),
+            length,
+            batch_size,
+            hidden_size);
+    }));
+}
+
+//  bidirectional forward()
+void sru_cuda_bi_forward_simple(
+        torch::Tensor & h,
+        torch::Tensor & c,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    const int threads = 512;
+    const int total = batch_size * hidden_size * 2;
+    const dim3 blocks( (total - 1) / threads + 1 );
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(U.type(), "sru_bi_forward_cuda_simple", ([&] {
+        sru_cuda_bi_forward_kernel_simple<scalar_t><<<blocks, threads>>>(
+            h.data<scalar_t>(),
+            c.data<scalar_t>(),
+            U.data<scalar_t>(),
+            x.numel() ? x.data<scalar_t>() : NULL,
+            weight_c.data<scalar_t>(),
+            bias.data<scalar_t>(),
+            c_init.data<scalar_t>(),
+            mask_c.numel() ? mask_c.data<scalar_t>() : NULL,
+            mask_pad.numel() ? mask_pad.data<unsigned char>() : NULL,
+            length,
+            batch_size,
+            hidden_size);
+    }));
+}
+
+//  bidirectional backward()
+void sru_cuda_bi_backward_simple(
+        torch::Tensor & grad_u,
+        torch::Tensor & grad_x,
+        torch::Tensor & grad_wc,
+        torch::Tensor & grad_bias,
+        torch::Tensor & grad_init,
+        const torch::Tensor & U,
+        const torch::Tensor & x,
+        const torch::Tensor & weight_c,
+        const torch::Tensor & bias,
+        const torch::Tensor & c_init,
+        const torch::Tensor & mask_c,
+        const torch::Tensor & mask_pad,
+        const torch::Tensor & c,
+        const torch::Tensor & grad_h,
+        const torch::Tensor & grad_last,
+        const int64_t length, 
+        const int64_t batch_size, 
+        const int64_t hidden_size) {
+
+    const int threads = 512;
+    const int total = batch_size * hidden_size * 2;
+    const dim3 blocks( (total - 1) / threads + 1 );
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(U.type(), "sru_bi_backward_cuda_simple", ([&] {
+        sru_cuda_bi_backward_kernel_simple<scalar_t><<<blocks, threads>>>(
+            grad_u.data<scalar_t>(),
+            grad_x.numel() ? grad_x.data<scalar_t>() : NULL,
+            grad_wc.data<scalar_t>(),
+            grad_bias.data<scalar_t>(),
+            grad_init.data<scalar_t>(),
+            U.data<scalar_t>(),
+            x.numel() ? x.data<scalar_t>() : NULL,
+            weight_c.data<scalar_t>(),
+            bias.data<scalar_t>(),
+            c_init.data<scalar_t>(),
+            mask_c.numel() ? mask_c.data<scalar_t>() : NULL,
+            mask_pad.numel() ? mask_pad.data<unsigned char>() : NULL,
+            c.data<scalar_t>(),
+            grad_h.data<scalar_t>(),
+            grad_last.data<scalar_t>(),
+            length,
+            batch_size,
+            hidden_size);
+    }));
+}
 
 //  unidirectional forward()
 void sru_cuda_forward(

--- a/sru/cuda_functional.py
+++ b/sru/cuda_functional.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 import torch
 from torch.autograd import Function
 
@@ -66,7 +65,6 @@ class SRU_Compute_GPU(Function):
         # call faster / simple version if possible
         is_simple_version = ((k_ == 3) and has_skip_term and (not is_custom)
                              and (activation_type == 0))
-        warnings.warn("is_simple_version: {}".format(is_simple_version))
         if is_simple_version:
             forward_func = sru_cuda_lib.sru_bi_forward_simple if bidirectional else \
                 sru_cuda_lib.sru_forward_simple

--- a/sru/modules.py
+++ b/sru/modules.py
@@ -42,7 +42,7 @@ class SRUCell(nn.Module):
                  has_skip_term: bool = True,
                  use_tanh: bool = False,
                  v1: bool = False,
-                 amp_recurrence_fp16: bool = False,
+                 amp_recurrence_fp16: bool = True,
                  weight_c_init: Optional[float] = None):
         """Initialize the SRUCell module.
 
@@ -390,7 +390,7 @@ class SRU(nn.Module):
                  v1: bool = False,
                  nn_rnn_compatible_return: bool = False,
                  proj_input_to_hidden_first: bool = False,
-                 amp_recurrence_fp16: bool = False,
+                 amp_recurrence_fp16: bool = True,
                  weight_c_init: Optional[float] = None):
         """Initialize the SRU module.
 


### PR DESCRIPTION
## What's changed?
- Changed `amp_recurrence_fp16 = True` by default. 
- Wrote cleaner versions of CUDA kernels for the most common case (i.e. no tanh activation, use highway and input_size == output_size). Might give some speed-up for small models.

## What tests / experiments were done?
- Trained 42M enwik8 language model with `amp_recurrence_fp16 = True`. got the same results.
- Training 250M wiki103 language model with `amp_recurrence_fp16 = True`. no dev result degradation observed.
- About 10% speedup improvement:
    - Enwik8 LM: 15.1 min per epoch -> 13.9 min per epoch
    - Wiki103 LM: 94 min per epoch -> 85 min per epoch
- GPU memory usage reduction during training
- (However, during evaluation w/ fp32 the memory usage on GPU:0 is as high as before)

## Pending
- Perhaps testing this PR on Autosuggest V4? (@hpasapp )
- If fp16 recurrence kernel works again, incorporate similar change as in [PR#158](https://github.com/asappresearch/sru/pull/158). Basically, simply cast all tensor types to that of input tensor U would be enough. 