### PR TITLE
remove autocast() block; eval in fp16

### DIFF
--- a/experiments/srupp_experiments/train_wt103.py
+++ b/experiments/srupp_experiments/train_wt103.py
@@ -141,6 +141,8 @@ def eval_model(model, valid, print_speed=False):
         total_tok = 0.0
         start_time = time.time()
         for x, y, seq_len in valid:
+            if torch.is_autocast_enabled():
+                torch.clear_autocast_cache()
             loss, hidden, memory = model(x, y, hidden, memory=memory)
             total_loss += loss.sum()
             total_tok += y.numel()
@@ -227,7 +229,6 @@ def main(args):
         dim=1,
         device_ids=[local_rank],
         output_device=local_rank,
-        find_unused_parameters=True,
         broadcast_buffers=False,
     )
 
@@ -329,7 +330,8 @@ def main(args):
 
                 if local_rank == 0 and (niter == args.max_iter or niter % args.eval_period == 0):
                     torch.cuda.empty_cache()
-                    dev_ppl, dev_loss = eval_model(model_, dev)
+                    with torch.cuda.amp.autocast(enabled=args.fp16):
+                        dev_ppl, dev_loss = eval_model(model_, dev)
                     dev_writer.add_scalar('loss/lm_loss', dev_loss, niter)
                     dev_writer.add_scalar('loss/avg_loss', dev_loss, niter)
                     dev_writer.add_scalar('loss/ppl', dev_ppl, niter)

--- a/sru/ops.py
+++ b/sru/ops.py
@@ -96,48 +96,33 @@ def elementwise_recurrence_gpu(U: Tensor,
     """
     from .cuda_functional import SRU_Compute_GPU
 
-    in_autocast = getattr(torch, 'is_autocast_enabled', lambda: False)()
-    if in_autocast:
-        with torch.cuda.amp.autocast(enabled=False):
-            cast = torch.Tensor.half if amp_recurrence_fp16 else torch.Tensor.float
-
-            U = cast(U)
-            x = cast(x)
-            weight_c = cast(weight_c)
-            bias = cast(bias)
-            c_init = cast(c_init)
-            scale_x = cast(scale_x) if scale_x is not None else scale_x
-            dropout_mask_c = cast(dropout_mask_c) if dropout_mask_c is not None else dropout_mask_c
-
-            return SRU_Compute_GPU.apply(
-                U,
-                x,
-                weight_c,
-                bias,
-                c_init,
-                activation_type,
-                hidden_size,
-                bidirectional,
-                has_skip_term,
-                scale_x,
-                dropout_mask_c,
-                mask_pad
-            )
+    if amp_recurrence_fp16 and U.dtype == torch.float16:
+        cast = torch.Tensor.half
     else:
-        return SRU_Compute_GPU.apply(
-            U,
-            x,
-            weight_c,
-            bias,
-            c_init,
-            activation_type,
-            hidden_size,
-            bidirectional,
-            has_skip_term,
-            scale_x,
-            dropout_mask_c,
-            mask_pad
-        )
+        cast = torch.Tensor.float
+
+    U = cast(U)
+    x = cast(x)
+    weight_c = cast(weight_c)
+    bias = cast(bias)
+    c_init = cast(c_init)
+    scale_x = cast(scale_x) if scale_x is not None else scale_x
+    dropout_mask_c = cast(dropout_mask_c) if dropout_mask_c is not None else dropout_mask_c
+
+    return SRU_Compute_GPU.apply(
+        U,
+        x,
+        weight_c,
+        bias,
+        c_init,
+        activation_type,
+        hidden_size,
+        bidirectional,
+        has_skip_term,
+        scale_x,
+        dropout_mask_c,
+        mask_pad
+    )
 
 
 @torch.jit.unused


### PR DESCRIPTION
This PR removes the `torch.amp.autocast(enabled=False)` block in `sru.ops.elementwise_recurrence_gpu`. This would simplify the code and make SRU compatible with both Pytorch Native AMP and apex.

The `amp_recurrence_fp16` controls if the elementwise recurrence kernel can be run in fp16 or not. After some testing, we believe this can be made default `True`, which gives additional speed-up and memory footprint reduction.

In addition, we made minor changes to the SRUpp experimental code to let dev evaluation running in fp16.