### PR TITLE
Speed up data loading / batching for ONE BILLION WORD experiment

### DIFF
--- a/experiments/srupp_experiments/data_utils.py
+++ b/experiments/srupp_experiments/data_utils.py
@@ -128,18 +128,6 @@ class Vocab(object):
 
         return encoded
 
-    def encode_file_stream(self, path, ordered=False, verbose=False, add_eos=True,
-            add_double_eos=False):
-        if verbose: print('encoding file {} ...'.format(path))
-        assert os.path.exists(path)
-        with open(path, 'r', encoding='utf-8') as f:
-            for idx, line in enumerate(f):
-                if verbose and idx > 0 and idx % 500000 == 0:
-                    print('    line {}'.format(idx))
-                symbols = self.tokenize(line, add_eos=add_eos,
-                    add_double_eos=add_double_eos)
-                yield self.convert_to_tensor(symbols)
-
     def encode_sents(self, sents, ordered=False, verbose=False):
         if verbose: print('encoding {} sents ...'.format(len(sents)))
         encoded = []


### PR DESCRIPTION
The data loading was inefficient and was found to be the bottleneck of BILLION WORD training. 
This PR rewrote the sharding (which data goes to a certain GPU / training process), and improved the training speed significantly.

The figure compares a previous run and a new test run. We see 40% reduction on training time.
<img src="https://user-images.githubusercontent.com/27778464/109981031-81ef8f80-7cce-11eb-8b89-1d55e9eb797a.png" width="60%">


This means our reported training efficiency will be much stronger
<img src="https://user-images.githubusercontent.com/27778464/109981431-e3176300-7cce-11eb-8976-955ae7ac8f42.png" width="40%">
from 59 GPU days to 36 GPU days, and 4x more efficient than FairSeq Transformer results.